### PR TITLE
feat: add GHC-DT graph with local MiniLM embeddings

### DIFF
--- a/ghc-dt/.env.example
+++ b/ghc-dt/.env.example
@@ -1,3 +1,8 @@
+# Required
 OPENAI_API_KEY=replace_me
 LANGSMITH_API_KEY=replace_me
 VECTORSTORE_DIR=vectorstore
+# Optional (HF cache; good for limited outbound)
+HF_HUB_DISABLE_TELEMETRY=1
+SENTENCE_TRANSFORMERS_HOME=/tmp/st_cache
+PLAN_DATA_DIR=/mnt/data

--- a/ghc-dt/.streamlit/secrets.toml
+++ b/ghc-dt/.streamlit/secrets.toml
@@ -1,0 +1,2 @@
+LANGSMITH_API_KEY = "replace_me"
+API_URL = "https://digital-roots-f97ac74784c6517184d8a7c3bbca5459.us.langgraph.app"

--- a/ghc-dt/apps/ghc_dt_control.py
+++ b/ghc-dt/apps/ghc_dt_control.py
@@ -13,7 +13,7 @@ client = get_sync_client(url=BASE, api_key=API_KEY)
 st.title("Green Hill CEO Digital Twin (GHC-DT)")
 msg = st.text_area("Message", "/brief Summarize EU-GMP readiness with citations.")
 if st.button("Run"):
-    a = client.assistants.search(graph_id="ghc_dt", limit=1)[0]
+    a = client.assistants.search(graph_id="ghc", limit=1)[0]
     t = client.threads.create(metadata={"audience":"internal"})
     with st.status("Streaming…"):
         for ev in client.runs.stream(

--- a/ghc-dt/config/ghc_dt_developer_prompt.txt
+++ b/ghc-dt/config/ghc_dt_developer_prompt.txt
@@ -1,0 +1,5 @@
+Guardrails: 
+- Never invent numbers, dates, or SHA clauses.
+- Cite only plan/appendix.
+- Public/investor questions → redacted summaries only.
+- Flag “Human sign-off required” for legal, tax, GMP-critical changes.

--- a/ghc-dt/config/ghc_dt_system_prompt.txt
+++ b/ghc-dt/config/ghc_dt_system_prompt.txt
@@ -1,0 +1,6 @@
+You are the Green Hill CEO Digital Twin (GHC-DT).
+Answer strictly from the Green Hill Strategic Plan (v10 pre-FINAL) and Appendix A. Cite like:
+“See Implementation Plan → Phase I”, “Appendix A3”, or “Endnote [25]”.
+Priorities: EU-GMP compliance, ZEC tax regime, governance (SHA 2024), freeze-drying line, financial model.
+Modes: /brief (5 bullets + cites), /deep (detailed, risks + mitigations), /action (checklist + DoD).
+Tone: executive, concise, investor-ready.

--- a/ghc-dt/graphs/ghc_dt/agent.py
+++ b/ghc-dt/graphs/ghc_dt/agent.py
@@ -1,23 +1,14 @@
 from langgraph.prebuilt import create_react_agent
-from langgraph.checkpoint.memory import InMemorySaver
 from langchain_openai import ChatOpenAI
 from graphs.shared.tools import ghc_docs
 
-SYSTEM = """
-You are the Green Hill Agent (GHC-DT helper).
-
-Priorities:
-1) Answer strictly from the Green Hill Strategic Plan (v10 pre-FINAL) and Appendix A (+ executive summaries).
-2) Always include document-style references (e.g., “Implementation Plan → Phase I”, “Appendix A3”, “Endnotes [5–10]”).
-3) Focus: EU-GMP & validation, ZEC, investor governance (SHA/PPLs/consents), freeze-drying, financial model, rollout.
-4) Modes: /brief (5 bullets + citations) /deep (assumptions/risks + citations) /action (owners, due, DoD).
-5) Guardrails: If confidence <0.7, say what section is missing; legal/tax/GMP changes need Human sign-off.
-"""
+SYSTEM = open("config/ghc_dt_system_prompt.txt").read()
+DEV = open("config/ghc_dt_developer_prompt.txt").read()
 
 def build_agent():
+    model = ChatOpenAI(model="gpt-4o", temperature=0)
     return create_react_agent(
-        model=ChatOpenAI(model="gpt-4o", temperature=0),
+        model=model,
         tools=[ghc_docs],
-        prompt=SYSTEM,
-        checkpointer=InMemorySaver(),
+        prompt=SYSTEM + "\n\n[Developer]\n" + DEV,
     )

--- a/ghc-dt/graphs/ghc_dt/entry.py
+++ b/ghc-dt/graphs/ghc_dt/entry.py
@@ -9,9 +9,9 @@ class S(TypedDict):
 def _node(state: S):
     agent = build_agent()
     res = agent.invoke(state)
-    return {"messages": res["messages"] if "messages" in res else res}
+    return {"messages": res["messages"]}
 
 graph = StateGraph(S)
-graph.add_node("ghc_dt", _node)
-graph.add_edge(START, "ghc_dt")
+graph.add_node("ghc", _node)
+graph.add_edge(START, "ghc")
 graph = graph.compile(checkpointer=InMemorySaver())

--- a/ghc-dt/graphs/shared/tools.py
+++ b/ghc-dt/graphs/shared/tools.py
@@ -1,45 +1,23 @@
-import os, pathlib
-from typing import List
 from langchain_community.vectorstores import FAISS
-from langchain_openai import OpenAIEmbeddings
+from langchain_community.embeddings import HuggingFaceEmbeddings
 from langchain_core.tools import tool
 
-VS_DIR = os.getenv("VECTORSTORE_DIR", "vectorstore")
+VS_DIR = "vectorstore"
 
-_FRIENDLY = {
-    "Strategic_Plan-GreenHill_v10-pre-FINAL.pdf": "Strategic Plan v10 pre-FINAL",
-    "Strategic_Plan-GreenHill_v10-pre-FINAL.docx": "Strategic Plan v10 pre-FINAL",
-    "appendex.docx": "Appendix A",
-    "ex sum implementation plan final.docx": "Implementation Plan",
-    "ex sum market overview final.docx": "Market Overview",
-    "ex sum company despcription final.docx": "Company Description",
-    "ex sum financial projections final.docx": "Financial Projections",
-    "ex sum risk analysis final.docx": "Risk Analysis",
-    "ex sum conclusion final.docx": "Conclusion",
-    "240726_SHA_Grren_Hill_1.pdf": "SHA 2024",
-}
-
-def _pretty_cite(meta: dict) -> str:
-    import os as _os
-    src = meta.get("source", "document")
-    page = meta.get("page")
-    name = _FRIENDLY.get(_os.path.basename(src), _os.path.basename(src))
-    return f"{name}, p.{page}" if page is not None else name
-
-def _load_vs():
-    if not os.path.isdir(VS_DIR):
-        raise RuntimeError(f"Vectorstore missing: {VS_DIR}/  (Run: python ingest/index_plan.py)")
-    return FAISS.load_local(VS_DIR, OpenAIEmbeddings(), allow_dangerous_deserialization=True)
+def _vs():
+    embed = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+    return FAISS.load_local(VS_DIR, embed, allow_dangerous_deserialization=True)
 
 @tool
 def ghc_docs(query: str) -> str:
-    """Search Green Hill plan & Appendix A; return 3–5 short, cited snippets."""
-    vs = _load_vs()
+    """Search Green Hill docs; return short cited snippets."""
+    vs = _vs()
     hits = vs.similarity_search(query, k=4)
-    if not hits:
-        return "No KB match. Refine query or rebuild vectorstore from data/."
-    out: List[str] = []
+    out = []
     for h in hits:
-        meta = getattr(h, "metadata", {}) or {}
-        out.append(f"- {h.page_content.strip().replace('\\n',' ')}\n  — {_pretty_cite(meta)}")
+        meta = h.metadata
+        src = meta.get("source", "doc")
+        page = meta.get("page")
+        cite = f"{src}" + (f", p.{page}" if page else "")
+        out.append(f"- {h.page_content.strip()}\n  [Source: {cite}]")
     return "\n".join(out)

--- a/ghc-dt/langgraph.json
+++ b/ghc-dt/langgraph.json
@@ -4,11 +4,10 @@
     "langchain_community",
     "faiss-cpu",
     "./graphs",
-    "./ingest",
-    "./apps"
+    "./config"
   ],
   "graphs": {
-    "ghc_dt": "./graphs/ghc_dt/entry.py:graph"
+    "ghc": "./graphs/ghc_dt/entry.py:graph"
   },
   "env": ".env"
 }

--- a/ghc-dt/requirements.txt
+++ b/ghc-dt/requirements.txt
@@ -1,8 +1,8 @@
 langgraph
 langchain-openai
 langchain-community
-langgraph-sdk
 faiss-cpu
 pypdf
 docx2txt
 streamlit
+sentence-transformers


### PR DESCRIPTION
## Summary
- add config prompts and .env/secrets templates
- expose ghc graph and Streamlit control panel
- use FAISS store with MiniLM embeddings for docs

## Testing
- `pip install -r requirements.txt`
- `PLAN_DATA_DIR=ghc-dt/data python ghc-dt/ingest/index_plan.py` *(fails: ProxyError to huggingface.co)*
- `curl -i -X POST "$BASE/assistants/search" -H "Content-Type: application/json" -H "X-Api-Key: $LANGSMITH_API_KEY" -d '{"graph_id":"ghc","limit":1}'` *(fails: CONNECT tunnel 403)*


------
https://chatgpt.com/codex/tasks/task_e_68a0c2ac714c8320ba71a042d56fc81a