### PR TITLE
feat: rebuild vectorstore with OpenAI embeddings

### DIFF
--- a/ghc-dt/graphs/shared/tools.py
+++ b/ghc-dt/graphs/shared/tools.py
@@ -1,12 +1,25 @@
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
 from langchain_community.vectorstores import FAISS
-from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_openai import OpenAIEmbeddings
 from langchain_core.tools import tool
 
-VS_DIR = "vectorstore"
+load_dotenv()
+if not os.getenv("OPENAI_API_KEY"):
+    raise EnvironmentError("OPENAI_API_KEY not found. Please set before ingestion.")
+
+VS_DIR = Path(__file__).resolve().parent / "vectorstore"
+
 
 def _vs():
-    embed = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
-    return FAISS.load_local(VS_DIR, embed, allow_dangerous_deserialization=True)
+    """Load the persisted FAISS vector store using OpenAI embeddings."""
+    return FAISS.load_local(
+        str(VS_DIR),
+        OpenAIEmbeddings(model="text-embedding-3-small"),
+        allow_dangerous_deserialization=True,
+    )
 
 @tool
 def ghc_docs(query: str) -> str:

--- a/ghc-dt/ingest/index_plan.py
+++ b/ghc-dt/ingest/index_plan.py
@@ -1,8 +1,15 @@
 import os
+from pathlib import Path
+
+from dotenv import load_dotenv
 from langchain_community.document_loaders import PyPDFLoader, Docx2txtLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_openai import OpenAIEmbeddings
 from langchain_community.vectorstores import FAISS
+
+load_dotenv()
+if not os.getenv("OPENAI_API_KEY"):
+    raise EnvironmentError("OPENAI_API_KEY not found. Please set before ingestion.")
 
 PLAN_DATA_DIR = os.getenv("PLAN_DATA_DIR", "data")
 DOCS = [f for f in os.listdir(PLAN_DATA_DIR) if f.endswith((".pdf", ".docx"))]
@@ -12,8 +19,11 @@ for f in DOCS:
     path = os.path.join(PLAN_DATA_DIR, f)
     docs += (PyPDFLoader(path).load() if f.endswith(".pdf") else Docx2txtLoader(path).load())
 
+# Split documents and embed with OpenAI
 splits = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=150).split_documents(docs)
-embed = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+embed = OpenAIEmbeddings(model="text-embedding-3-small")
 vs = FAISS.from_documents(splits, embed)
-vs.save_local("vectorstore")
-print(f"Indexed → ./vectorstore  (files: {len(DOCS)})")
+base_dir = Path(__file__).resolve().parent.parent
+vs_dir = base_dir / "graphs" / "shared" / "vectorstore"
+vs.save_local(str(vs_dir))
+print(f"Indexed → {vs_dir}  (files: {len(DOCS)})")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 langchain>=0.2.10
 langgraph>=0.2.5
 langchain-openai
+python-dotenv
 langchain-huggingface
 langchain-chroma
 chromadb


### PR DESCRIPTION
## Summary
- load OpenAI API key from environment or `.env` and require it for plan ingestion and query tools
- persist FAISS vectorstore under `graphs/shared` using `text-embedding-3-small`
- add `python-dotenv` to dependencies for environment variable loading

## Testing
- `PLAN_DATA_DIR=./ghc-dt/data python ghc-dt/ingest/index_plan.py` *(fails: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443): Max retries exceeded with url: /encodings/cl100k_base.tiktoken (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_68a0cef3ab6c8320a7cf291423632c8c