### PR TITLE
Add persistent memory and startup scripts

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,8 @@
 from pathlib import Path
+import json
 import uuid
+from datetime import datetime
+
 import streamlit as st
 import chromadb
 from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
@@ -7,6 +10,35 @@ from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunct
 PERSIST_DIR = Path(".chroma").as_posix()
 MODEL_NAME = "all-MiniLM-L6-v2"
 COLLECTION = "greenhill"
+
+STATE_PATH = Path("state.json")
+DEFAULT_STATE = {
+    "command_priority": "user_first",
+    "last_tasks": [],
+    "approver": "CEO",
+    "mode": "shadow",
+}
+
+
+def load_state():
+    if STATE_PATH.exists():
+        try:
+            return json.loads(STATE_PATH.read_text())
+        except Exception:
+            pass
+    return DEFAULT_STATE.copy()
+
+
+def save_state(state):
+    STATE_PATH.write_text(json.dumps(state, indent=2))
+
+
+def record_action(action, **kwargs):
+    state = st.session_state.setdefault("persistent_state", load_state())
+    entry = {"action": action, "timestamp": datetime.utcnow().isoformat()}
+    entry.update(kwargs)
+    state.setdefault("last_tasks", []).append(entry)
+    save_state(state)
 
 @st.cache_resource(show_spinner=False)
 def get_collection():
@@ -23,17 +55,48 @@ coll = get_collection()
 st.set_page_config(page_title="Green Hill Corpus Hub", page_icon="📚")
 st.title("Green Hill Corpus Hub")
 
+state = st.session_state.setdefault("persistent_state", load_state())
+
+with st.sidebar:
+    st.header("State")
+    st.json(state, expanded=False)
+
 text = st.text_area("Enter text to ingest")
 if st.button("Ingest text"):
     if text.strip():
         coll.add(documents=[text], ids=[str(uuid.uuid4())])
         st.success("Ingested")
+        record_action("ingest_text")
     else:
         st.warning("No text provided")
 
-uploaded_files = st.file_uploader("Upload text files", accept_multiple_files=True, type=["txt", "md"])
+uploaded_files = st.file_uploader(
+    "Upload text files", accept_multiple_files=True, type=["txt", "md"]
+)
 if st.button("Ingest files") and uploaded_files:
     for file in uploaded_files:
         content = file.read().decode("utf-8", errors="ignore")
-        coll.add(documents=[content], ids=[str(uuid.uuid4())], metadatas=[{"source": file.name}])
+        coll.add(
+            documents=[content],
+            ids=[str(uuid.uuid4())],
+            metadatas=[{"source": file.name}],
+        )
+        record_action("ingest_file", source=file.name)
     st.success("Files ingested")
+
+query = st.text_input("Search corpus")
+if st.button("Search corpus"):
+    if query.strip():
+        results = coll.query(query_texts=[query], n_results=5)
+        st.session_state["search_results"] = results
+        st.session_state["last_query"] = query
+        record_action("search", query=query)
+    else:
+        st.warning("No query provided")
+
+if "search_results" in st.session_state:
+    st.subheader("Search Results")
+    st.write(st.session_state["search_results"])
+    if st.button("Approve search"):
+        record_action("approval", query=st.session_state.get("last_query"))
+        st.success("Approved")

--- a/start_console.ps1
+++ b/start_console.ps1
@@ -1,0 +1,1 @@
+.\venv\Scripts\Activate.ps1 ; streamlit run app.py

--- a/start_console.sh
+++ b/start_console.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+source venv/bin/activate && streamlit run app.py

--- a/state.json
+++ b/state.json
@@ -1,0 +1,6 @@
+{
+  "command_priority": "user_first",
+  "last_tasks": [],
+  "approver": "CEO",
+  "mode": "shadow"
+}


### PR DESCRIPTION
## Summary
- extend `app.py` with persistent state file, search & approval logging, and new Chroma client
- add cross-platform startup scripts for running Streamlit
- include default `state.json` to track session memory

## Testing
- `python -c "import streamlit,chromadb,pandas;print('imports ok')"`
- `streamlit run app.py`

------
https://chatgpt.com/codex/tasks/task_e_68a165b067408320aa7a2ee3f3c7fa0b